### PR TITLE
optional dependency and JAR support

### DIFF
--- a/android-release-aar.gradle
+++ b/android-release-aar.gradle
@@ -5,6 +5,11 @@ def groupId = project.PUBLISH_GROUP_ID
 def artifactId = project.PUBLISH_ARTIFACT_ID
 def version = project.PUBLISH_VERSION
 
+configurations {
+    optional
+    compile.extendsFrom optional
+}
+
 def localReleaseDest = "${buildDir}/release/${version}"
 
 task androidJavadocs(type: Javadoc) {

--- a/android-release-aar.gradle
+++ b/android-release-aar.gradle
@@ -32,6 +32,22 @@ uploadArchives {
         pom.groupId = groupId
         pom.artifactId = artifactId
         pom.version = version
+        
+        pom.withXml {
+            asNode().dependencies.dependency.findAll { xmlDep ->
+                // mark optional dependencies
+                if (project.configurations.optional.allDependencies.findAll { dep ->
+                    xmlDep.groupId.text() == dep.group && xmlDep.artifactId.text() == dep.name
+                }) {
+                    def xmlOptional = xmlDep.optional[0];
+                    if (!xmlOptional) {
+                        xmlOptional = xmlDep.appendNode('optional')
+                    }
+                    xmlOptional.value = 'true';
+                }
+            }
+        }
+        
         // Add other pom properties here if you want (developer details / licenses)
         repository(url: "file://${localReleaseDest}")
     }

--- a/android-release-jar.gradle
+++ b/android-release-jar.gradle
@@ -14,7 +14,7 @@ def localReleaseDest = "${buildDir}/release/${version}"
 
 android.libraryVariants.all { variant ->
     def name = variant.buildType.name
-    if (!name.equals(com.android.builder.core.BuilderConstants.DEBUG)) {
+    if (!name.equals("debug")) {
         def task = project.tasks.create "jar${name.capitalize()}", Jar
         task.dependsOn variant.javaCompile
         task.from variant.javaCompile.destinationDir

--- a/android-release-jar.gradle
+++ b/android-release-jar.gradle
@@ -1,0 +1,84 @@
+// ./gradlew clean build generateRelease
+apply plugin: 'maven'
+
+def groupId = project.PUBLISH_GROUP_ID
+def artifactId = project.PUBLISH_ARTIFACT_ID
+def version = project.PUBLISH_VERSION
+
+configurations {
+    optional
+    compile.extendsFrom optional
+}
+
+def localReleaseDest = "${buildDir}/release/${version}"
+
+android.libraryVariants.all { variant ->
+    def name = variant.buildType.name
+    if (!name.equals(com.android.builder.core.BuilderConstants.DEBUG)) {
+        def task = project.tasks.create "jar${name.capitalize()}", Jar
+        task.dependsOn variant.javaCompile
+        task.from variant.javaCompile.destinationDir
+        artifacts.add('archives', task);
+    }
+}
+
+task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+}
+
+task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+uploadArchives {
+    repositories.mavenDeployer {
+        pom.groupId = groupId
+        pom.artifactId = artifactId
+        pom.version = version
+        
+        pom.withXml {
+            asNode().dependencies.dependency.findAll { xmlDep ->
+                // mark optional dependencies
+                if (project.configurations.optional.allDependencies.findAll { dep ->
+                    xmlDep.groupId.text() == dep.group && xmlDep.artifactId.text() == dep.name
+                }) {
+                    def xmlOptional = xmlDep.optional[0];
+                    if (!xmlOptional) {
+                        xmlOptional = xmlDep.appendNode('optional')
+                    }
+                    xmlOptional.value = 'true';
+                }
+            }
+        }
+        
+        // Add other pom properties here if you want (developer details / licenses)
+        repository(url: "file://${localReleaseDest}")
+    }
+}
+
+task zipRelease(type: Zip) {
+    from localReleaseDest
+    destinationDir buildDir
+    archiveName "release-${version}.zip"
+}
+
+task generateRelease << {
+    println "Release ${version} can be found at ${localReleaseDest}/"
+    println "Release ${version} zipped can be found ${buildDir}/release-${version}.zip"
+}
+
+generateRelease.dependsOn(uploadArchives)
+generateRelease.dependsOn(zipRelease)
+
+
+artifacts {
+    archives androidSourcesJar
+    archives androidJavadocsJar
+}


### PR DESCRIPTION
- added support for optional dependency
- created android-release-jar.gradle that create package with jar to deploy jar package and not aar

more info: http://theartofdev.com/2015/02/19/publish-android-library-to-bintray-jcenter-aar-vs-jar-and-optional-dependency/

Thx for the script, it was really helpful.