### PR TITLE
Add script for building jars from java modules

### DIFF
--- a/java-release-jar.gradle
+++ b/java-release-jar.gradle
@@ -1,0 +1,48 @@
+// ./gradlew clean build generateRelease
+apply plugin: 'maven'
+
+def groupId = project.PUBLISH_GROUP_ID
+def artifactId = project.PUBLISH_ARTIFACT_ID
+def version = project.PUBLISH_VERSION
+
+def localReleaseDest = "${buildDir}/release/${version}"
+
+task sourcesJar(type: Jar, dependsOn:classes) {
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn:javadoc) {
+  classifier = 'javadoc'
+  from javadoc.destinationDir
+}
+
+uploadArchives {
+  repositories.mavenDeployer {
+    pom.groupId = groupId
+    pom.artifactId = artifactId
+    pom.version = version
+
+    // Add other pom properties here if you want (developer details / licenses)
+    repository(url: "file://${localReleaseDest}")
+  }
+}
+
+task zipRelease(type: Zip) {
+  from localReleaseDest
+  destinationDir buildDir
+  archiveName "release-${version}.zip"
+}
+
+task generateRelease << {
+  println "Release ${version} can be found at ${localReleaseDest}/"
+  println "Release ${version} zipped can be found ${buildDir}/release-${version}.zip"
+}
+
+generateRelease.dependsOn(uploadArchives)
+generateRelease.dependsOn(zipRelease)
+
+artifacts {
+  archives sourcesJar
+  archives javadocJar
+}


### PR DESCRIPTION
As far as I can tell, the existing scripts in this repo only work for android modules. This slightly-modified script should do the same thing, but for java-only modules.
