### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Remote script to create a maven compatible release of an android library (aar). 
 
 Matching blog post here: [blog.blundell-apps.com/locally-release-an-android-library-for-jcenter-or-maven-central-inclusion/](http://blog.blundell-apps.com/locally-release-an-android-library-for-jcenter-or-maven-central-inclusion/)
 
-####adding to your library
+#### adding to your library
 ```
 apply plugin: 'com.android.library'
 
@@ -30,11 +30,11 @@ apply from: 'https://raw.githubusercontent.com/blundell/release-android-library/
 ```
 
 
-####useage
+#### useage
 
 `./gradlew clean build generateRelease`
 
-####example output
+#### example output
 
 
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
