### PR TITLE
fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ release-android-library
 
 Remote script to create a maven compatible release of an android library (aar). This release comes in a zip or exploded form and is only created locally inside your own build folder. You can these use these files to release to JCenter or Maven Central.
 
-Matching blog post here: [blog.blundell-apps.com/locally-release-an-android-library-for-jcenter-or-maven-central-inclusion/](http://blog.blundell-apps.com/locally-release-an-android-library-for-jcenter-or-maven-central-inclusion/)
+Matching blog post here: [http://blog.blundellapps.co.uk/locally-release-an-android-library-for-jcenter-or-maven-central-inclusion/](http://blog.blundellapps.co.uk/locally-release-an-android-library-for-jcenter-or-maven-central-inclusion/)
 
 #### adding to your library
 ```


### PR DESCRIPTION
The README links to an incorrect domain that seems to just forward through some ad tracking domains.